### PR TITLE
Fix modul.json

### DIFF
--- a/BMW/module.json
+++ b/BMW/module.json
@@ -7,6 +7,6 @@
     "parentRequirements": [],
     "childRequirements": [],
     "implemented": [],
-    "prefix": "BMW"
+    "prefix": "BMW",
     "url": "https://github.com/demel42/IPSymconBMWConnectedDrive/README.md"
 }


### PR DESCRIPTION
Es fehlt ein Komma.

Fehlermeldung:
ModuleLoader         | Fehler in module.json: Parse Fehler. Datei: C:\ProgramData\Symcon\modules\IPSymconBMWConnectedDrive\BMW\module.json