### PR TITLE
Servicemeldungen

### DIFF
--- a/BMW/module.php
+++ b/BMW/module.php
@@ -1618,7 +1618,8 @@ class BMWConnectedDrive extends IPSModule
             if ($requiredServices != '') {
                 foreach ($requiredServices as $requiredService) {
                     $title = $requiredService['title'];
-                    $desc = $requiredService['longDescription'];
+                    if (isset($requiredService['longDescription'])) $desc = $requiredService['longDescription'];
+                    else $desc = "";
                     $subtitle = $requiredService['subtitle'];
                     $tbl .= '<tr>' . PHP_EOL;
                     $tbl .= '<td>' . $title . '</td>' . PHP_EOL;


### PR DESCRIPTION
'longDescription' gibt es nicht bei jeder Servicemeldung. Dadurch kommt es zu einer Fehlermeldung
![grafik](https://user-images.githubusercontent.com/35669489/146251624-33f3331a-263a-4aec-97a7-95344ae921f2.png)
